### PR TITLE
Trying to avoid temporary files...

### DIFF
--- a/asc2qr.sh
+++ b/asc2qr.sh
@@ -48,13 +48,13 @@ fi
 ## Split the key file into usable chunks that the QR encoder can consume
 chunks=()
 while true; do
-    s=$( head -c ${max_qr_bytes} )
+    s=$( dd bs=${max_qr_bytes} count=1 2>/dev/null )
     if [ ${#s} -gt 0 ]; then
         chunks+=("${s}")
     else
         break
     fi
-done <<< "$( cat ${asc_key} )"
+done < ${asc_key}
 
 ## For each chunk, encode it into a qr image
 index=1

--- a/asc2qr.sh
+++ b/asc2qr.sh
@@ -48,7 +48,7 @@ fi
 ## Split the key file into usable chunks that the QR encoder can consume
 chunks=()
 while true; do
-    s=$( dd bs=${max_qr_bytes} count=1 2>/dev/null )
+    IFS= read -r -d'\0' -n ${max_qr_bytes} s
     if [ ${#s} -gt 0 ]; then
         chunks+=("${s}")
     else

--- a/asc2qr.sh
+++ b/asc2qr.sh
@@ -28,7 +28,7 @@
 
 # Maximum chuck size to send to the QR encoder. QR version 40 supports
 # 2,953 bytes of storage.
-file_split_size=2800
+max_qr_bytes=2800
 
 # Prefix string for the PNG images that are produced
 image_prefix="QR"
@@ -45,38 +45,27 @@ if [ ! -f ${asc_key} ]; then
 	exit 1
 fi
 
-# Create a temp file to use as a pattern for splitting the input key file.
-# This helps protect against file collisions in the current directory.
-export TMPDIR=""
-tmp_file=$(mktemp keyparts.XXXXXX)
-if [ $? -ne 0 ]; then
-	echo "failed to create temporary file"
-	exit 1
-fi
+## Split the key file into usable chunks that the QR encoder can consume
+chunks=()
+while true; do
+    s=$( head -c ${max_qr_bytes} )
+    echo "$s"
+    if [ ${#s} -gt 0 ]; then
+        chunks+=("${s}")
+    else
+        break
+    fi
+done <<< "$( cat ${asc_key} )"
 
-# Split the key file into usable chunks that the QR encoder can consume
-split -b ${file_split_size} ${asc_key} "${tmp_file}."
-
-# For each chunk, encode it into a qc image
+## For each chunk, encode it into a qr image
 index=1
-for file in ${tmp_file}.*; do
-	img="${image_prefix}${index}.png"
-	echo "generating ${img}"
-	cat ${file} | qrencode -o ${img}
+for c in "${chunks[@]}"; do
+    img="${image_prefix}${index}.png"
+    echo "generating ${img}"
+    echo -n "${c}" | qrencode -o ${img}
 	if [ $? -ne 0 ]; then
 		echo "failed to encode image"
 		exit 2
 	fi
 	index=$((index+1))
 done
-
-# Find the correct secure deletion utility (srm on Mac, shred on Linux)
-sec_del="srm"
-which ${sec_del} 2>&1 1>/dev/null
-if [ $? -ne 0 ]; then
-	sec_del="shred --remove"
-fi
-
-# Securely clean up temporary files
-${sec_del} ${tmp_file}
-${sec_del} ${tmp_file}.*

--- a/asc2qr.sh
+++ b/asc2qr.sh
@@ -49,7 +49,6 @@ fi
 chunks=()
 while true; do
     s=$( head -c ${max_qr_bytes} )
-    echo "$s"
     if [ ${#s} -gt 0 ]; then
         chunks+=("${s}")
     else

--- a/qr2asc.sh
+++ b/qr2asc.sh
@@ -44,6 +44,10 @@ for img in "$@"; do
 	asc_key="${tmp_file}.${index}"
 	echo "decoding ${img}"
     chunk=$( zbarimg --raw ${img} 2>/dev/null | perl -p -e 'chomp if eof' )
+    # Please use this next line instead of teh one above if zbarimg does
+    # not decode the qr code properly in tests
+    # (zbarimg needs to be told it is being given a qr code to decode)
+    #chunk=$( zbarimg --raw --set disable --set qrcode.enable ${img} 2>/dev/null )
 	if [ $? -ne 0 ]; then
 		echo "failed to decode QR image"
 		exit 2

--- a/qr2asc.sh
+++ b/qr2asc.sh
@@ -33,15 +33,6 @@ if [ $# -lt 1 ]; then
 	exit 1
 fi
 
-# Create a temp file to use as a pattern for splitting the input key file.
-# This helps protect against file collisions in the current directory.
-export TMPDIR=""
-tmp_file=$(mktemp keyparts.XXXXXX)
-if [ $? -ne 0 ]; then
-	echo "failed to create temporary file"
-	exit 1
-fi
-
 # For each image on the command line, decode it into text
 chunks=()
 index=1

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+if [ $# -eq 0 ]; then
+    echo "usage: $(basename ${0}) <ascii armor key file>"
+    exit 1
+fi
+
+set -x
+
+asc_key="$1"
+
+./asc2qr.sh "${asc_key}"
+
+./qr2asc.sh QR*.png
+
+diff "${asc_key}" "./mykey.asc"
+if [ $? -eq 0 ]; then
+    echo "Diff Test: PASS"
+else
+    echo "Diff Test: FAIL"
+fi
+
+rm ./QR*.png
+rm ./mykey.asc


### PR DESCRIPTION
The point of this change is to avoid having to
1. create temporary files with parts of our private key (slightly kludgy and reduces the overall security of the asc2qr or qr2asc process)
2. securely delete temporary files (adds dependencies like shred, etc.)

The solution proposed is to use bash arrays to hold the key pieces in memory so that they never hit the disk. This uses another bash feature (required already) while reducing dependency on other applications.
