### PR TITLE
Hotfix/explicit zbarimg symbols

### DIFF
--- a/qr2asc.sh
+++ b/qr2asc.sh
@@ -43,7 +43,7 @@ for img in "$@"; do
 	fi
 	asc_key="${tmp_file}.${index}"
 	echo "decoding ${img}"
-    chunk=$( zbarimg --raw -Sdisable -Sqrcode.enable ${img} 2>/dev/null )
+    chunk=$( zbarimg --raw --set disable --set qrcode.enable ${img} 2>/dev/null )
 	if [ $? -ne 0 ]; then
 		echo "failed to decode QR image"
 		exit 2

--- a/qr2asc.sh
+++ b/qr2asc.sh
@@ -52,7 +52,7 @@ for img in "$@"; do
 	fi
 	asc_key="${tmp_file}.${index}"
 	echo "decoding ${img}"
-    chunk=$( zbarimg --raw ${img} 2>/dev/null | perl -p -e 'chomp if eof' )
+    chunk=$( zbarimg --raw -Sdisable -Sqrcode.enable ${img} 2>/dev/null )
 	if [ $? -ne 0 ]; then
 		echo "failed to decode QR image"
 		exit 2


### PR DESCRIPTION
I was finding that zbarimg in its "raw" mode was interleaving qrcode output as well as output from one of its other symbols modules. By explicitly specifying that we are scanning a qrcode, the zbarimg output is less likely to have output which is not pertaining to the qrcode data. This should allow the script to be more robust.
